### PR TITLE
OLMIS-5283: Add Deployment Script for Reporting

### DIFF
--- a/deployment/reporting_env/services/deploy_services.sh
+++ b/deployment/reporting_env/services/deploy_services.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+export DOCKER_TLS_VERIFY="1"
+export DOCKER_HOST="tcp://nifi-registry.openlmis.org:2376"
+export DOCKER_CERT_PATH="${PWD}/credentials"
+export DOCKER_COMPOSE_BIN=/usr/local/bin/docker-compose
+export REPORTING_DIR_NAME=reporting
+
+reportingRepo=$1
+
+cp -r "$credentials" "$DOCKER_CERT_PATH"
+cd "$reportingRepo/$REPORTING_DIR_NAME"
+$DOCKER_COMPOSE_BIN kill
+$DOCKER_COMPOSE_BIN down -v
+$DOCKER_COMPOSE_BIN up --build --force-recreate -d


### PR DESCRIPTION
Add a script for deploying the reporting stack from the Jenkins hosts.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>