### PR TITLE
OLMIS-5231: Update Terraform Vars Holding AWS Keys

### DIFF
--- a/provision/terraform/README.md
+++ b/provision/terraform/README.md
@@ -74,3 +74,19 @@ Use the following steps to set up the machine you'll be running Terraform from:
     ```
 
 1. Add the right key to SSH-Agent.  e.g. `ssh-add TestEnvDockerHost.env`
+
+### Creating openlmis infrastructure from existing environment
+
+1. `cd` to directory holding environment.  e.g. `cd uat/uat3`
+1. Ensure you're using the right virtualenv. e.g. `workon openlmis-deployment`
+1. (optional) `terrform plan` to see which resources will be created.
+1. `terraform apply` to create the environment.
+1. Create/update the DNS CNAME in Gandi to point to the new ELB.
+1. Once done the needed Docker TLS client keys will be in the S3 bucket 
+`aws-instance-keys`:
+    1. Download the following files from `/tls/<name of environment>/<ip>/<date>/`:
+        - `ca/cert.pem` -> `ca.pem`
+        - `jenkins/key.pem` -> `key.pem`
+       - `jenkins/cert.pem` -> `cert.pem`
+    1. Zip the above files into `DockerClientTls-<name of environemt>.zip`
+    1. Upload Zip file above to Jenkins Credentials and use in `deploy-to` job.

--- a/provision/terraform/README.md
+++ b/provision/terraform/README.md
@@ -69,8 +69,8 @@ Use the following steps to set up the machine you'll be running Terraform from:
   following commands to set the Terraform variables:
 
     ```sh
-    export TF_VAR_aws-access-key-id=AWS_ACCESS_KEY_ID
-    export TF_VAR_aws-secret-access-key=AWS_SECRET_ACCESS_KEY
+    export TF_VAR_aws_access_key_id=$AWS_ACCESS_KEY_ID
+    export TF_VAR_aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
     ```
 
 1. Add the right key to SSH-Agent.  e.g. `ssh-add TestEnvDockerHost.env`

--- a/provision/terraform/reporting/nifi-registry/main.tf
+++ b/provision/terraform/reporting/nifi-registry/main.tf
@@ -28,7 +28,7 @@ module "nifi-registry" {
   nr-instance-ssh-user        = "${var.nr-instance-ssh-user}"
   docker-ansible-dir          = "${var.docker-ansible-dir}"
   nr-dns-name                 = "${var.nr-dns-name}"
-  nr-tls-s3-access-key-id     = "${var.aws-access-key-id}"
-  nr-tls-s3-secret-access-key = "${var.aws-secret-access-key}"
+  nr-tls-s3-access-key-id     = "${var.aws_access_key_id}"
+  nr-tls-s3-secret-access-key = "${var.aws_secret_access_key}"
   docker-tls-port             = "${var.docker-tls-port}"
 }

--- a/provision/terraform/reporting/nifi-registry/variables.tf
+++ b/provision/terraform/reporting/nifi-registry/variables.tf
@@ -73,12 +73,12 @@ variable "nr-dns-name" {
   description = "The DNS name associated to NiFi Registry"
 }
 
-variable "aws-access-key-id" {
+variable "aws_access_key_id" {
   type        = "string"
   description = "The AWS access key ID to use to backup generated Docker TLS files"
 }
 
-variable "aws-secret-access-key" {
+variable "aws_secret_access_key" {
   type        = "string"
   description = "The AWS secrect access key to use to backup generated Docker TLS files"
 }

--- a/provision/terraform/uat/benin-demo/main.tf
+++ b/provision/terraform/uat/benin-demo/main.tf
@@ -17,8 +17,8 @@ module "benin-demo" {
   app-instance-ssh-user        = "${var.app-instance-ssh-user}"
   docker-ansible-dir           = "${var.docker-ansible-dir}"
   docker-tls-port              = "${var.docker-tls-port}"
-  app-tls-s3-access-key-id     = "${var.aws-access-key-id}"
-  app-tls-s3-secret-access-key = "${var.aws-secret-access-key}"
+  app-tls-s3-access-key-id     = "${var.aws_access_key_id}"
+  app-tls-s3-secret-access-key = "${var.aws_secret_access_key}"
   app-dns-name                 = "${var.app-dns-name}"
   app-instance-group           = "${var.app-instance-group}"
 }

--- a/provision/terraform/uat/benin-demo/variables.tf
+++ b/provision/terraform/uat/benin-demo/variables.tf
@@ -18,12 +18,12 @@ variable "docker-tls-port" {
   description = "The TCP port The Docker Daemon is listening for TLS traffic"
 }
 
-variable "aws-access-key-id" {
+variable "aws_access_key_id" {
   type        = "string"
   description = "The AWS access key ID to use to backup generated Docker TLS files"
 }
 
-variable "aws-secret-access-key" {
+variable "aws_secret_access_key" {
   type        = "string"
   description = "The AWS secrect access key to use to backup generated Docker TLS files"
 }

--- a/provision/terraform/uat/reporting-gap-data/main.tf
+++ b/provision/terraform/uat/reporting-gap-data/main.tf
@@ -17,8 +17,8 @@ module "reporting-gap-data" {
   app-instance-ssh-user        = "${var.app-instance-ssh-user}"
   docker-ansible-dir           = "${var.docker-ansible-dir}"
   docker-tls-port              = "${var.docker-tls-port}"
-  app-tls-s3-access-key-id     = "${var.aws-access-key-id}"
-  app-tls-s3-secret-access-key = "${var.aws-secret-access-key}"
+  app-tls-s3-access-key-id     = "${var.aws_access_key_id}"
+  app-tls-s3-secret-access-key = "${var.aws_secret_access_key}"
   app-dns-name                 = "${var.app-dns-name}"
   app-instance-group           = "${var.app-instance-group}"
 }

--- a/provision/terraform/uat/reporting-gap-data/variables.tf
+++ b/provision/terraform/uat/reporting-gap-data/variables.tf
@@ -18,12 +18,12 @@ variable "docker-tls-port" {
   description = "The TCP port The Docker Daemon is listening for TLS traffic"
 }
 
-variable "aws-access-key-id" {
+variable "aws_access_key_id" {
   type        = "string"
   description = "The AWS access key ID to use to backup generated Docker TLS files"
 }
 
-variable "aws-secret-access-key" {
+variable "aws_secret_access_key" {
   type        = "string"
   description = "The AWS secrect access key to use to backup generated Docker TLS files"
 }

--- a/provision/terraform/uat/uat3/main.tf
+++ b/provision/terraform/uat/uat3/main.tf
@@ -17,8 +17,8 @@ module "uat3" {
   app-instance-ssh-user        = "${var.app-instance-ssh-user}"
   docker-ansible-dir           = "${var.docker-ansible-dir}"
   docker-tls-port              = "${var.docker-tls-port}"
-  app-tls-s3-access-key-id     = "${var.aws-access-key-id}"
-  app-tls-s3-secret-access-key = "${var.aws-secret-access-key}"
+  app-tls-s3-access-key-id     = "${var.aws_access_key_id}"
+  app-tls-s3-secret-access-key = "${var.aws_secret_access_key}"
   app-dns-name                 = "${var.app-dns-name}"
   app-instance-group           = "${var.app-instance-group}"
 }

--- a/provision/terraform/uat/uat3/variables.tf
+++ b/provision/terraform/uat/uat3/variables.tf
@@ -18,12 +18,12 @@ variable "docker-tls-port" {
   description = "The TCP port The Docker Daemon is listening for TLS traffic"
 }
 
-variable "aws-access-key-id" {
+variable "aws_access_key_id" {
   type        = "string"
   description = "The AWS access key ID to use to backup generated Docker TLS files"
 }
 
-variable "aws-secret-access-key" {
+variable "aws_secret_access_key" {
   type        = "string"
   description = "The AWS secrect access key to use to backup generated Docker TLS files"
 }

--- a/provision/terraform/uat/uat4/main.tf
+++ b/provision/terraform/uat/uat4/main.tf
@@ -17,8 +17,8 @@ module "uat4" {
   app-instance-ssh-user        = "${var.app-instance-ssh-user}"
   docker-ansible-dir           = "${var.docker-ansible-dir}"
   docker-tls-port              = "${var.docker-tls-port}"
-  app-tls-s3-access-key-id     = "${var.aws-access-key-id}"
-  app-tls-s3-secret-access-key = "${var.aws-secret-access-key}"
+  app-tls-s3-access-key-id     = "${var.aws_access_key_id}"
+  app-tls-s3-secret-access-key = "${var.aws_secret_access_key}"
   app-dns-name                 = "${var.app-dns-name}"
   app-instance-group           = "${var.app-instance-group}"
 }

--- a/provision/terraform/uat/uat4/variables.tf
+++ b/provision/terraform/uat/uat4/variables.tf
@@ -18,12 +18,12 @@ variable "docker-tls-port" {
   description = "The TCP port The Docker Daemon is listening for TLS traffic"
 }
 
-variable "aws-access-key-id" {
+variable "aws_access_key_id" {
   type        = "string"
   description = "The AWS access key ID to use to backup generated Docker TLS files"
 }
 
-variable "aws-secret-access-key" {
+variable "aws_secret_access_key" {
   type        = "string"
   description = "The AWS secrect access key to use to backup generated Docker TLS files"
 }


### PR DESCRIPTION
Update the Terraform variables holding AWS keys from using hyphens to
using underscores to allow the variables to be passed as environment
variables (using the 'TF_VAR' prefix).

Environment variables cannot have hyphens.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>