### PR TITLE
Update the Instance Type for the Reporting UAT EC2

### DIFF
--- a/provision/terraform/reporting/nifi-registry/terraform.tfvars
+++ b/provision/terraform/reporting/nifi-registry/terraform.tfvars
@@ -1,4 +1,4 @@
-nr-instance-type = "t2.medium"
+nr-instance-type = "m5a.large"
 nr-volume-size = "200"
 nr-ssh-key = "openlmis-reporting"
 nr-name = "nifi-registry.openlmis.org"


### PR DESCRIPTION
Upgrade the instance type for the UAT reporting EC2 instance to
m5a.large as NiFi was running out of memory in the t2.medium instance.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>