### PR TITLE
OLMIS 6229 Update Backup service to use env_file

### DIFF
--- a/deployment/reporting_env/nifi-registry/deploy_nifi_registry.sh
+++ b/deployment/reporting_env/nifi-registry/deploy_nifi_registry.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
 export DOCKER_TLS_VERIFY="1"
 export COMPOSE_TLS_VERSION=TLSv1_2
 export DOCKER_HOST="tcp://nifi-registry.openlmis.org:2376"

--- a/deployment/reporting_env/nifi-registry/docker-compose.yml
+++ b/deployment/reporting_env/nifi-registry/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - flow-storage:${BACKUP_DIRECTORY}/nifi-registry-persistence
     env_file: settings.env
     environment:
+      BACKUP_CRON_SCHEDULE: ${BACKUP_CRON_SCHEDULE}
       BACKUP_DIRECTORY: ${BACKUP_DIRECTORY}
   scalyr:
     image: openlmis/scalyr:${OL_SCALYR_AGENT_VERSION}

--- a/deployment/reporting_env/nifi-registry/docker-compose.yml
+++ b/deployment/reporting_env/nifi-registry/docker-compose.yml
@@ -15,13 +15,7 @@ services:
       - flow-storage:${BACKUP_DIRECTORY}/nifi-registry-persistence
     env_file: settings.env
     environment:
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}
-      BACKUP_CRON_SCHEDULE: ${BACKUP_CRON_SCHEDULE}
       BACKUP_DIRECTORY: ${BACKUP_DIRECTORY}
-      S3_BACKUP_URI: ${S3_BACKUP_URI}
-
   scalyr:
     image: openlmis/scalyr:${OL_SCALYR_AGENT_VERSION}
     volumes:


### PR DESCRIPTION
Use the settings.env to load S3 credentials instead of setting them on the host env vars