### PR TITLE
Remove the JVM_HEAP_MAX env var

### DIFF
--- a/deployment/reporting_env/services/deploy_services.sh
+++ b/deployment/reporting_env/services/deploy_services.sh
@@ -14,7 +14,6 @@ export NIFI_ENABLE_SSL=false
 export NIFI_BEHIND_LOAD_BALANCER=true
 export NIFI_LOAD_BALANCER_REDIRECT_HTTP=true
 export NIFI_DOMAIN_NAME=nifi.uat.openlmis.org
-export NIFI_JVM_HEAP_MAX=1g
 
 reportingRepo=$1
 


### PR DESCRIPTION
The reporting stack environment file sets the `NIFI_JVM_HEAP_INIT` and `NIFI_JVM_HEAP_MAX`
Let the deployment use that